### PR TITLE
fix: 修复 scorecard 工作流文件名拼写错误及无效参数

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -63,8 +63,6 @@ jobs:
           #   - `publish_results` 将始终设置为 `false`，
           #     无论在此处输入的值如何。
           publish_results: true
-          # 使用 OIDC 进行身份验证（无需手动登录）
-          use_oidc: true
 
           # (可选) 如果您有标记为 export-ignore 的文件的 .gitattributes，请取消注释 file_mode
           # file_mode: git
@@ -83,4 +81,4 @@ jobs:
       - name: "上传到代码扫描"
         uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
         with:
-          sarif_file: results.sariff
+          sarif_file: results.sarif


### PR DESCRIPTION
## 修复说明

修复 GitHub Actions `供应链安全评分` 工作流（scorecard.yml）中的两个错误：

### 问题 1：文件名拼写错误
- `上传到代码扫描` 步骤中 `sarif_file: results.sariff` 多了一个 `f`
- 导致报错：`Path does not exist: results.sariff`
- 修复：`results.sariff` -> `results.sarif`

### 问题 2：无效输入参数
- `use_oidc: true` 不是 `ossf/scorecard-action@v2.4.3` 的有效输入参数
- 导致警告：`Unexpected input(s) 'use_oidc'`
- 修复：移除 `use_oidc: true` 配置

### 相关运行
https://github.com/xiaomizhoubaobei/LLM-Playground/actions/runs/26036159278

关联 CNB Issue #28

## Summary by Sourcery

Fix issues in the supply chain security scorecard GitHub Actions workflow configuration.

CI:
- Remove unsupported use_oidc input from the ossf/scorecard-action step in the scorecard workflow.
- Correct the SARIF upload step to reference the proper results.sarif file path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration with corrected file path reference and adjusted authentication settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xiaomizhoubaobei/LLM-Playground/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->